### PR TITLE
Asio

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "CMake/CMakeLatex"]
 	path = CMake/CMakeLatex
 	url = https://github.com/wichtounet/CMakeLatex.git
+[submodule "dependencies/asio"]
+	path = dependencies/asio
+	url = https://github.com/chriskohlhoff/asio.git

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -1,5 +1,9 @@
 # author: 8112887052852
+
+include(ExternalProject)
+
 add_subdirectory(gtest)
 
-include_directories(gtest/googletest/include)
-include_directories(gtest/googlemock/include)
+add_library(asio INTERFACE)
+target_sources(asio INTERFACE ${CMAKE_CURRENT_LIST_DIR}/asio/asio/include/asio.hpp)
+

--- a/doc/file_registery.tex
+++ b/doc/file_registery.tex
@@ -10,6 +10,7 @@
 				[\file{CMakeLatex}{opensource community}{submodule}]
 			]
 			[dependencies
+				[\file{asio}{opensource community}{submodule}]
 				[\file{gtest}{opensource community}{submodule}]
 				[\file{CMakeLists.txt}{8112887052852}{build script}]	
 			]

--- a/src/TestoWoSyslog/CMakeLists.txt
+++ b/src/TestoWoSyslog/CMakeLists.txt
@@ -1,7 +1,10 @@
 # author: 8112887052852
 add_executable(TestliboWoSyslog
-	main.cpp)
+	main.cpp
+	)
 
 target_link_libraries(TestliboWoSyslog
 	gtest
-	gmock)
+	gmock
+	asio
+	)


### PR DESCRIPTION
# Asio
* Added the asio submodule
* Link|include the asio headers by adding asio the the target linked libraries
E.g.: `target_link_libraries(TestliboWoSyslog asio)`